### PR TITLE
Fixes dehumidifier’s device class.

### DIFF
--- a/custom_components/Hitachi_smart_app/humidifier.py
+++ b/custom_components/Hitachi_smart_app/humidifier.py
@@ -54,6 +54,10 @@ class HitachiDehumidifier(HitachiBaseEntity, HumidifierEntity):
 
 
     @property
+    def device_class(self):
+        return DEVICE_CLASS_DEHUMIDIFIER
+
+    @property
     def label(self):
         return ""
 


### PR DESCRIPTION
This PR sets the correct device class for dehumidifier so the description in HomeKit makes sense.

Before
<img width="128" alt="Screen Shot 2021-07-10 at 22 23 00" src="https://user-images.githubusercontent.com/76374/125166295-8a505d80-e1cd-11eb-9f6e-f5137ca12d1e.png">

After
<img width="120" alt="Screen Shot 2021-07-10 at 22 23 06" src="https://user-images.githubusercontent.com/76374/125166299-8e7c7b00-e1cd-11eb-981b-259fc6cf180a.png">
